### PR TITLE
cmake: fix ZMQ_STATIC define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ if(MSVC)
     PUBLIC_HEADER "${public_headers}"
     RELEASE_POSTFIX "${_zmq_COMPILER}-mt-s-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     DEBUG_POSTFIX "${_zmq_COMPILER}-mt-sgd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
-    COMPILE_FLAGS "/D ZMQ_STATIC"
+    COMPILE_FLAGS "/DZMQ_STATIC"
     OUTPUT_NAME "libzmq")
 else()
     add_library(libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig})


### PR DESCRIPTION
The space goes missing in the command line and it ends up defining the
/Fo parameter which causes the file to not appear in the correct output
directory.